### PR TITLE
Changed the password env variable to MQTT_PASSWORD

### DIFF
--- a/Docker/src/conf/broker.py
+++ b/Docker/src/conf/broker.py
@@ -18,7 +18,7 @@ keepAlive = os.getenv('KEEPALIVE', 60)
 #
 #===========================================================================
 user = os.getenv('MQTT_USER', None)
-password = os.getenv('MQTT_PASS', None)
+password = os.getenv('MQTT_PASSWORD', None)
 
 #===========================================================================
 #


### PR DESCRIPTION
I thought updating the environment variable used would be better than updating the documentation due to the number of comments / examples I saw on the web referencing MQTT_PASSWORD